### PR TITLE
Added Dimension Feature

### DIFF
--- a/common/src/main/java/net/minescript/common/Minescript.java
+++ b/common/src/main/java/net/minescript/common/Minescript.java
@@ -2775,6 +2775,8 @@ public class Minescript {
           result.difficulty = difficulty.getSerializedName();
           result.name = getWorldName();
           result.address = serverAddress;
+          var dimensionKey = world.dimension().toString();
+          result.dimension = dimensionKey.substring(dimensionKey.lastIndexOf('/') + 2, dimensionKey.length() - 1);
           return ScriptValue.of(result);
         }
 

--- a/common/src/main/java/net/minescript/common/dataclasses/WorldInfo.java
+++ b/common/src/main/java/net/minescript/common/dataclasses/WorldInfo.java
@@ -15,4 +15,5 @@ public class WorldInfo extends Jsonable {
   public String difficulty;
   public String name;
   public String address;
+  public String dimension;
 }

--- a/common/src/main/resources/system/lib/minescript.py
+++ b/common/src/main/resources/system/lib/minescript.py
@@ -784,6 +784,7 @@ class WorldInfo:
   difficulty: str
   name: str
   address: str
+  dimension: str
 
 def world_info() -> WorldInfo:
   """Gets world properties.

--- a/test/minescript_test.py
+++ b/test/minescript_test.py
@@ -668,7 +668,8 @@ def screen_name_test():
 @test
 def world_info_test():
   info = minescript.world_info()
-  expect_equal(len(info.__dict__), 9)
+  expect_equal(len(info.__dict__), 10)
+  expect_equal(info.dimension, "minecraft:overworld")
 
 
 @test

--- a/test/minescript_test.py
+++ b/test/minescript_test.py
@@ -669,7 +669,7 @@ def screen_name_test():
 def world_info_test():
   info = minescript.world_info()
   expect_equal(len(info.__dict__), 10)
-  expect_equal(info.dimension, "minecraft:overworld")
+  expect_startswith(info.dimension, "minecraft:")
 
 
 @test


### PR DESCRIPTION
Adds the current Minecraft dimension to the `WorldInfo` object returned by `world_info()`.

## Usage

```python
import minescript

info = minescript.world_info()
minescript.echo(info.dimension)
```

Example output in the Overworld:

```text
minecraft:overworld
```

Other vanilla values include `minecraft:the_nether` and `minecraft:the_end`.

## Testing

Updated `world_info_test()` to expect the new field and verify that the returned dimension uses the `minecraft:` namespace.