### PR TITLE
Fix #62: Allow unbounded yaw in player_set_orientation

### DIFF
--- a/common/src/main/java/net/minescript/common/Minescript.java
+++ b/common/src/main/java/net/minescript/common/Minescript.java
@@ -2665,14 +2665,14 @@ public class Minescript {
         }
 
       case "player_set_orientation":
-        {
+      {
           args.expectSize(2);
           Double yaw = args.getDouble(0);
           Double pitch = args.getDouble(1);
-          player.setYRot(yaw.floatValue() % 360.0f);
-          player.setXRot(pitch.floatValue() % 360.0f);
+          player.setYRot(yaw.floatValue());
+          player.setXRot(pitch.floatValue());
           return ScriptValue.TRUE;
-        }
+      }
 
       case "player_get_targeted_block":
         {


### PR DESCRIPTION
Fixed #62 

Removed the unnecessary modulo by 360 in the player_set_orientation function

In Minecraft, besides the f3 menu, almost everything in the game stores the yaw value as unbounded/unwrapped. So values like 1000° are valid, because they preserve full rotation history.

This fix importantly makes minescript able to achieve natural movement similar to a normal vanilla client.

It also allows for the arm snapping issue to stop (view video attached to understand)

VIDEOS:
Before my fix: [here](https://github.com/user-attachments/assets/eca4b0a1-6898-43e0-a77e-30cac27ee2c9) or https://github.com/user-attachments/assets/eca4b0a1-6898-43e0-a77e-30cac27ee2c9
After my fix: [here](https://github.com/user-attachments/assets/c3660e7a-deb0-4f43-bf23-29fa1397c945) or https://github.com/user-attachments/assets/c3660e7a-deb0-4f43-bf23-29fa1397c945