### PR TITLE
Fix packing after adding a blockpack

### DIFF
--- a/common/src/main/resources/system/lib/minescript.py
+++ b/common/src/main/resources/system/lib/minescript.py
@@ -2315,6 +2315,9 @@ class BlockPacker:
       self._flush_blocks()
 
   def _flush_blocks(self):
+    if self.offset is None:
+      return
+
     if sys.byteorder != "big":
       # Swap to network (big-endian) byte order.
       self.setblocks.byteswap()

--- a/test/minescript_test.py
+++ b/test/minescript_test.py
@@ -462,6 +462,11 @@ def blockpack_test():
   comments = blockpack.comments()
   expect_equal({"hello": "world", "foo": "bar"}, comments)
 
+  blockpacker = minescript.BlockPacker()
+  blockpacker.add_blockpack(blockpack)
+  repacked_blockpack = blockpacker.pack()
+  expect_equal(blockpack.block_bounds(), repacked_blockpack.block_bounds())
+
 
 @test
 def await_loaded_region_test():


### PR DESCRIPTION
## What changed

- Skip `BlockPacker._flush_blocks()` when there are no buffered Python `setblock()` or `fill()` operations.
- Add an integration regression test that adds a `BlockPack` to a fresh `BlockPacker`, packs it, and verifies the block bounds are preserved.

## Why

`add_blockpack()` writes directly to the Java-side block packer and does not initialize the Python buffer offset. `pack()` nevertheless called `_flush_blocks()`, which passed the unset offset as `null` to `blockpacker_add_blocks` and raised an `IllegalArgumentException`.

This guard avoids the invalid empty flush while preserving existing buffered `setblock()` and `fill()` behavior.

Fixes #50.

## Validation

- `python3 -m py_compile common/src/main/resources/system/lib/minescript.py test/minescript_test.py`
- `git diff --check`
- `./gradlew build` reaches project configuration but cannot complete because `org.pyjinn:pyjinn-lib:0.14` is unavailable from the repositories configured by the project.
