### PR TITLE
Preserve environment for script subprocesses

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     compileOnly group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'
     annotationProcessor group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'
     api "org.pyjinn:pyjinn-lib:${pyjinn_version}:all"
+    testImplementation 'junit:junit:4.13.2'
 }
 
 configurations {
@@ -56,4 +57,3 @@ artifacts {
     commonJava sourceSets.main.java.sourceDirectories.singleFile
     commonResources sourceSets.main.resources.sourceDirectories.singleFile
 }
-

--- a/common/src/main/java/net/minescript/common/SubprocessProcessBuilder.java
+++ b/common/src/main/java/net/minescript/common/SubprocessProcessBuilder.java
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 jkramer5103 <info@jkramertech.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package net.minescript.common;
+
+final class SubprocessProcessBuilder {
+  private SubprocessProcessBuilder() {}
+
+  static ProcessBuilder create(String[] command, String[] environmentVariables) {
+    var processBuilder = new ProcessBuilder(command);
+    var environment = processBuilder.environment();
+    for (String variable : environmentVariables) {
+      int separator = variable.indexOf('=');
+      if (separator < 1) {
+        throw new IllegalArgumentException("Invalid environment variable: " + variable);
+      }
+      environment.put(variable.substring(0, separator), variable.substring(separator + 1));
+    }
+    return processBuilder;
+  }
+}

--- a/common/src/main/java/net/minescript/common/SubprocessTask.java
+++ b/common/src/main/java/net/minescript/common/SubprocessTask.java
@@ -46,7 +46,7 @@ public class SubprocessTask implements Task {
     }
 
     try {
-      process = Runtime.getRuntime().exec(exec.command(), exec.environment());
+      process = SubprocessProcessBuilder.create(exec.command(), exec.environment()).start();
     } catch (IOException e) {
       jobControl.logJobException(e);
       return -2;

--- a/common/src/test/java/net/minescript/common/SubprocessProcessBuilderTest.java
+++ b/common/src/test/java/net/minescript/common/SubprocessProcessBuilderTest.java
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 jkramer5103 <info@jkramertech.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package net.minescript.common;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import org.junit.Test;
+
+public class SubprocessProcessBuilderTest {
+  @Test
+  public void createProcessBuilderInheritsAndOverridesEnvironment() {
+    Map<String, String> environment =
+        SubprocessProcessBuilder.create(
+                new String[] {"command"},
+                new String[] {
+                  "MINESCRIPT_TEST_OVERRIDE=overridden", "MINESCRIPT_TEST_VALUE=one=two"
+                })
+            .environment();
+
+    for (var inherited : System.getenv().entrySet()) {
+      if (!inherited.getKey().equals("MINESCRIPT_TEST_OVERRIDE")
+          && !inherited.getKey().equals("MINESCRIPT_TEST_VALUE")) {
+        assertEquals(inherited.getValue(), environment.get(inherited.getKey()));
+      }
+    }
+    assertEquals("overridden", environment.get("MINESCRIPT_TEST_OVERRIDE"));
+    assertEquals("one=two", environment.get("MINESCRIPT_TEST_VALUE"));
+  }
+}


### PR DESCRIPTION
## What changed

- launch script subprocesses with `ProcessBuilder` so they inherit Minecraft's environment
- overlay Minescript's configured `PYTHONPATH`, `MINESCRIPT_COMMAND_PATH`, and custom command environment values
- add a regression test covering inherited variables, overrides, and values containing `=`

## Root cause

`Runtime.exec(command, envp)` treats a non-null `envp` as the subprocess's complete environment. Minescript passed only its custom variables, so standard Windows variables such as `LOCALAPPDATA` were removed.

The Windows Python Install Manager uses `LOCALAPPDATA` while scanning unmanaged installations. When Minescript launched the default `WindowsApps\\python3.exe` alias without that variable, Python Manager tried to construct a path from `None` and printed:

```
[WARNING] Failed to read unmanaged installs: expected str, bytes or os.PathLike object, not NoneType
```

Python Manager catches that exception and continues, which is why scripts still worked while the warning appeared for every invocation.

Fixes #69.

## Validation

- `./gradlew --configure-on-demand :common:test` — passes
- `:common:compileJava` — passes as part of the test task
- `git diff --check` — passes

The repository's unrestricted Gradle configuration currently fails before task execution because ForgeGradle rejects the repository's Gradle 9.2 wrapper. Configuration-on-demand isolates and validates the affected `common` module.
