### PR TITLE
Clarify Pyjinn-only Minescript import

### DIFF
--- a/common/src/main/resources/system/pyj/minescript.py
+++ b/common/src/main/resources/system/pyj/minescript.py
@@ -11,6 +11,11 @@
 Minescript standard library for Pyjinn scripts.
 """
 
+if "__script__" not in globals():
+  raise ImportError(
+      "system.pyj.minescript is only available to Pyjinn scripts (.pyj); "
+      "Python scripts should use `import minescript`")
+
 import system.pyj.sys as sys
 
 if "Pyjinn" not in sys.version:

--- a/test/issue_68_test.py
+++ b/test/issue_68_test.py
@@ -1,0 +1,16 @@
+"""Regression test for https://github.com/maxuser0/minescript/issues/68."""
+
+import sys
+from pathlib import Path
+
+
+resources = Path(__file__).parents[1] / "common" / "src" / "main" / "resources"
+sys.path.insert(0, str(resources))
+
+try:
+  import system.pyj.minescript  # noqa: E402,F401
+except ImportError as e:
+  expected = "system.pyj.minescript is only available to Pyjinn scripts (.pyj)"
+  assert expected in str(e), str(e)
+else:
+  raise AssertionError("CPython unexpectedly imported the Pyjinn-only Minescript module")


### PR DESCRIPTION
## Summary

- detect when the Pyjinn-only Minescript module is imported by CPython
- replace the indirect `JavaClass` `NameError` with an actionable `ImportError`
- add a regression script covering the CPython import path

## Root cause

`system.pyj.minescript` is intended for Pyjinn `.pyj` scripts. When CPython imported it, module initialization continued into `system.pyj.sys`, where the Pyjinn-provided `JavaClass` built-in does not exist. This produced a misleading `NameError` instead of explaining the interpreter mismatch.

Python `.py` scripts should import the regular `minescript` module. Pyjinn `.pyj` scripts can continue importing `system.pyj.minescript`.

## Validation

- `python3 test/issue_68_test.py`
- `git diff --check`
- confirmed `system.pyj.sys` imports successfully with the bundled Pyjinn 0.14 interpreter

Fixes #68
