### PR TITLE
Serialize item components with registry context

### DIFF
--- a/common/src/main/java/net/minescript/common/Minescript.java
+++ b/common/src/main/java/net/minescript/common/Minescript.java
@@ -2581,9 +2581,11 @@ public class Minescript {
           args.expectSize(0);
           var handItems = new HandItems();
           handItems.main_hand =
-              ItemStackData.of(player.getMainHandItem(), OptionalInt.empty(), false);
+              ItemStackData.of(
+                  player.getMainHandItem(), OptionalInt.empty(), false, world.registryAccess());
           handItems.off_hand =
-              ItemStackData.of(player.getOffhandItem(), OptionalInt.empty(), false);
+              ItemStackData.of(
+                  player.getOffhandItem(), OptionalInt.empty(), false, world.registryAccess());
           return ScriptValue.of(handItems);
         }
 
@@ -2596,7 +2598,9 @@ public class Minescript {
           for (int i = 0; i < inventory.getContainerSize(); i++) {
             var itemStack = inventory.getItem(i);
             if (itemStack.getCount() > 0) {
-              result.add(ItemStackData.of(itemStack, OptionalInt.of(i), i == selectedSlot));
+              result.add(
+                  ItemStackData.of(
+                      itemStack, OptionalInt.of(i), i == selectedSlot, world.registryAccess()));
             }
           }
           return ScriptValue.of(result.toArray(ItemStackData[]::new));
@@ -2913,7 +2917,9 @@ public class Minescript {
               if (itemStack.isEmpty()) {
                 continue;
               }
-              result.add(ItemStackData.of(itemStack, OptionalInt.of(slot.index), false));
+              result.add(
+                  ItemStackData.of(
+                      itemStack, OptionalInt.of(slot.index), false, world.registryAccess()));
             }
             return ScriptValue.of(result.toArray(ItemStackData[]::new));
           } else {

--- a/common/src/main/java/net/minescript/common/dataclasses/ItemStackData.java
+++ b/common/src/main/java/net/minescript/common/dataclasses/ItemStackData.java
@@ -4,6 +4,7 @@
 package net.minescript.common.dataclasses;
 
 import java.util.OptionalInt;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.Tag;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.item.ItemStack;
@@ -22,12 +23,16 @@ public class ItemStackData extends Jsonable {
     this.count = count;
   }
 
-  public static ItemStackData of(ItemStack itemStack, OptionalInt slot, boolean markSelected) {
+  public static ItemStackData of(
+      ItemStack itemStack,
+      OptionalInt slot,
+      boolean markSelected,
+      HolderLookup.Provider registries) {
     if (itemStack.getCount() == 0) {
       return null;
     } else {
       var reporter = new ProblemReporter.Collector();
-      var nbtOutput = TagValueOutput.createWithoutContext(reporter);
+      var nbtOutput = TagValueOutput.createWithContext(reporter, registries);
       nbtOutput.store("minescript_item_wrapper", ItemStack.CODEC, itemStack);
       Tag nbt = nbtOutput.buildResult().get("minescript_item_wrapper");
 

--- a/test/minescript_test.py
+++ b/test/minescript_test.py
@@ -509,6 +509,35 @@ def player_inventory_test():
 
 
 @test
+def player_inventory_components_test():
+  Minecraft = java.JavaClass("net.minecraft.client.Minecraft")
+  ItemStack = java.JavaClass("net.minecraft.world.item.ItemStack")
+  Items = java.JavaClass("net.minecraft.world.item.Items")
+  Registries = java.JavaClass("net.minecraft.core.registries.Registries")
+  Enchantments = java.JavaClass("net.minecraft.world.item.enchantment.Enchantments")
+
+  minecraft = Minecraft.getInstance()
+  inventory = minecraft.player.getInventory()
+  selected_slot = inventory.getSelectedSlot()
+  original_item = inventory.getItem(selected_slot).copy()
+
+  enchanted_sword = ItemStack(Items.WOODEN_SWORD)
+  enchantments = minecraft.level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT)
+  enchanted_sword.enchant(enchantments.getOrThrow(Enchantments.SHARPNESS), 2)
+
+  try:
+    inventory.setItem(selected_slot, enchanted_sword)
+    selected_item = next(
+        item for item in minescript.player_inventory() if item.slot == selected_slot)
+    expect_equal("minecraft:wooden_sword", selected_item.item)
+    expect_true(selected_item.nbt is not None)
+    expect_contains(selected_item.nbt, '"minecraft:enchantments"')
+    expect_contains(selected_item.nbt, '"minecraft:sharpness":2')
+  finally:
+    inventory.setItem(selected_slot, original_item)
+
+
+@test
 def player_test():
   name = minescript.player_name()
   x, y, z = minescript.player_position()


### PR DESCRIPTION
## Summary

Restore item stack serialization for registry-backed data components, including enchantments, in `player_inventory()`, `player_hand_items()`, and `container_get_items()`.

Fixes #67.

## Root cause

Minecraft 1.20.5 moved item metadata such as enchantments from legacy item NBT into data components. MineScript serializes an `ItemStack` with `ItemStack.CODEC` so that those components remain available through the existing `ItemStack.nbt` field.

The current serialization path creates a `TagValueOutput` without a registry context. Registry-backed components such as `minecraft:enchantments` contain holder references that the codec cannot encode without registry lookups. The store operation therefore produces no `minescript_item_wrapper` tag, and `ItemStackData.nbt` remains `null` even though the stack has components.

## Fix

- Pass the active client world's registry provider into `ItemStackData.of(...)` at every item-stack API call site.
- Use `TagValueOutput.createWithContext(...)` so `ItemStack.CODEC` can resolve and serialize registry-backed components.
- Preserve the existing Python API and SNBT representation. No new field or compatibility layer is required.

For example, a Sharpness II wooden sword now produces:

```text
{components:{"minecraft:enchantments":{"minecraft:sharpness":2}},count:1,id:"minecraft:wooden_sword"}
```

## Regression coverage

Add an in-game integration test that:

1. creates a wooden sword and obtains Sharpness from the active world's enchantment registry;
2. applies Sharpness II and temporarily places the stack in the selected inventory slot;
3. calls the public `player_inventory()` API;
4. asserts the item ID, non-null `nbt`, enchantment component, and level; and
5. restores the original stack in a `finally` block.

This test fails on the context-free serialization path and covers the public behavior reported in #67.

## Validation

- `python3 -m py_compile test/minescript_test.py`
- `./gradlew --configure-on-demand :fabric:build :neoforge:build`
- Tested in Minecraft 26.2 with the reporter's Sharpness II wooden sword; `player_inventory()` returned the expected `minecraft:enchantments` component and level.
