### PR TITLE
Restore player_inventory_slot_to_hotbar on Minecraft 26.2

### DIFF
--- a/common/src/main/java/net/minescript/common/Minescript.java
+++ b/common/src/main/java/net/minescript/common/Minescript.java
@@ -71,6 +71,7 @@ import net.minecraft.network.chat.ComponentSerialization;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -2604,9 +2605,20 @@ public class Minescript {
 
       case "player_inventory_slot_to_hotbar":
         {
-          throw new UnsupportedOperationException(
-              "player_inventory_slot_to_hotbar: support for ServerboundPickItemPacket removed in"
-                  + " Minecraft 1.21.4");
+          args.expectSize(1);
+          int slot = args.getStrictInt(0);
+          var inventory = player.getInventory();
+          var menu = player.containerMenu;
+          int menuSlot =
+              menu.findSlot(inventory, slot)
+                  .orElseThrow(
+                      () ->
+                          new IllegalArgumentException(
+                              "Inventory slot " + slot + " is not available in the current menu"));
+          int selectedSlot = inventory.getSelectedSlot();
+          minecraft.gameMode.handleContainerInput(
+              menu.containerId, menuSlot, selectedSlot, ContainerInput.SWAP, player);
+          return ScriptValue.of(selectedSlot);
         }
 
       case "player_inventory_select_slot":

--- a/common/src/main/resources/system/lib/minescript.py
+++ b/common/src/main/resources/system/lib/minescript.py
@@ -290,9 +290,6 @@ def player_inventory_slot_to_hotbar(slot: int) -> int:
   Returns:
     hotbar slot (0-8) into which the inventory item was swapped
 
-  Update in mc1.21.4:
-    No longer supported because ServerboundPickItemPacket was removed in Minecraft 1.21.4.
-
   Update in v4.0:
     Removed `done_callback` arg. Use `player_inventory_slot_to_hotbar.as_async(...)`
     for async execution.

--- a/common/src/main/resources/system/pyj/minescript.py
+++ b/common/src/main/resources/system/pyj/minescript.py
@@ -201,6 +201,24 @@ def player_inventory() -> List[ItemStack]:
   return __mcall__("player_inventory", [])
 
 
+def player_inventory_slot_to_hotbar(slot: int) -> int:
+  """Swaps an inventory item into the hotbar.
+
+  Args:
+    slot: inventory slot (9 or higher) to swap into the hotbar
+
+  Returns:
+    hotbar slot (0-8) into which the inventory item was swapped
+
+  Update in v4.0:
+    Removed `done_callback` arg. Use `player_inventory_slot_to_hotbar.as_async(...)`
+    for async execution.
+
+  Since: v3.0
+  """
+  return __mcall__("player_inventory_slot_to_hotbar", [slot])
+
+
 def player_inventory_select_slot(slot: int) -> int:
   """Selects the given slot within the player's hotbar.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1170,9 +1170,6 @@ Swaps an inventory item into the hotbar.
 
 - hotbar slot (0-8) into which the inventory item was swapped
 
-Update in mc1.21.4:
-  No longer supported because ServerboundPickItemPacket was removed in Minecraft 1.21.4.
-
 Update in v4.0:
   Removed `done_callback` arg. Use `player_inventory_slot_to_hotbar.as_async(...)`
   for async execution.
@@ -3068,4 +3065,3 @@ Asynchronously waits for the next event to occur.
   Returns:
     The event that occurred, or `None` if the timeout was reached.
   
-

--- a/test/minescript_test.py
+++ b/test/minescript_test.py
@@ -509,6 +509,33 @@ def player_inventory_test():
 
 
 @test
+def player_inventory_slot_to_hotbar_test():
+  def items_by_slot():
+    return {item.slot: item for item in minescript.player_inventory()}
+
+  def contents(item):
+    return None if item is None else (item.item, item.count, item.nbt)
+
+  inventory_slot = 9
+  before = items_by_slot()
+  hotbar_slot = None
+  try:
+    hotbar_slot = minescript.player_inventory_slot_to_hotbar(inventory_slot)
+    expect_true(0 <= hotbar_slot <= 8)
+    after_swap = items_by_slot()
+    expect_equal(contents(before.get(inventory_slot)), contents(after_swap.get(hotbar_slot)))
+    expect_equal(contents(before.get(hotbar_slot)), contents(after_swap.get(inventory_slot)))
+  finally:
+    if hotbar_slot is not None:
+      restored_hotbar_slot = minescript.player_inventory_slot_to_hotbar(inventory_slot)
+
+  expect_equal(hotbar_slot, restored_hotbar_slot)
+  restored = items_by_slot()
+  expect_equal(contents(before.get(inventory_slot)), contents(restored.get(inventory_slot)))
+  expect_equal(contents(before.get(hotbar_slot)), contents(restored.get(hotbar_slot)))
+
+
+@test
 def player_test():
   name = minescript.player_name()
   x, y, z = minescript.player_position()


### PR DESCRIPTION
## Summary

- restore `player_inventory_slot_to_hotbar()` after the removal of `ServerboundPickItemPacket`
- resolve the requested player inventory slot in the active container menu and send the standard server-authoritative hotbar `SWAP` input
- remove the obsolete unsupported notice from the Python and generated Markdown documentation
- add an in-game integration regression test that verifies the swap and restores the original inventory contents

## Root cause

Minecraft removed `ServerboundPickItemPacket` in 1.21.4. Minescript replaced the old implementation with an unconditional `UnsupportedOperationException`, leaving the API unavailable in later maintained versions, including 26.2.

Using the normal container input path preserves server authority and avoids the client/server inventory desynchronization that a client-only inventory mutation would cause.

## Validation

- manually confirmed in Minecraft 26.2
- `python3 -m py_compile test/minescript_test.py common/src/main/resources/system/lib/minescript.py`
- Fabric: `NO_MINESCRIPT_NEOFORGE_BUILD=1 NO_MINESCRIPT_FORGE_BUILD=1 ./gradlew :fabric:build`
- NeoForge: `NO_MINESCRIPT_FORGE_BUILD=1 NO_MINESCRIPT_FABRIC_BUILD=1 ./gradlew :neoforge:build`

Fixes #26
