### PR TITLE
Add tablist API for player list data

### DIFF
--- a/common/src/main/java/net/minescript/common/Minescript.java
+++ b/common/src/main/java/net/minescript/common/Minescript.java
@@ -2788,6 +2788,10 @@ public class Minescript {
                           .selectFrom(world.players())));
         }
 
+      case "tablist":
+        args.expectSize(0);
+        return ScriptValue.of(TabListExporter.export(minecraft));
+
       case "entities":
         {
           args.expectArgs(

--- a/common/src/main/java/net/minescript/common/TabListExporter.java
+++ b/common/src/main/java/net/minescript/common/TabListExporter.java
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2022-2026 Greg Christiana <maxuser@minescript.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package net.minescript.common;
+
+import com.mojang.serialization.JsonOps;
+import java.util.Comparator;
+import net.minecraft.Optionull;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.PlayerInfo;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentSerialization;
+import net.minecraft.network.chat.numbers.StyledFormat;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.scores.DisplaySlot;
+import net.minecraft.world.scores.PlayerTeam;
+import net.minecraft.world.scores.ScoreHolder;
+import net.minecraft.world.scores.criteria.ObjectiveCriteria;
+import net.minescript.common.dataclasses.TabListData;
+import net.minescript.common.dataclasses.TabListObjectiveData;
+import net.minescript.common.dataclasses.TabListPlayerData;
+import net.minescript.common.dataclasses.TabListTextData;
+import net.minescript.common.mixin.PlayerTabOverlayAccessor;
+
+/** Exports the same network-backed entries and metadata rendered by the player-list overlay. */
+public final class TabListExporter {
+  private static final Comparator<PlayerInfo> PLAYER_COMPARATOR =
+      Comparator.comparingInt((PlayerInfo player) -> -player.getTabListOrder())
+          .thenComparingInt(player -> player.getGameMode() == GameType.SPECTATOR ? 1 : 0)
+          .thenComparing(
+              player -> Optionull.mapOrDefault(player.getTeam(), PlayerTeam::getName, ""))
+          .thenComparing(player -> player.getProfile().name(), String::compareToIgnoreCase);
+
+  private TabListExporter() {}
+
+  public static TabListData export(Minecraft minecraft) {
+    var overlay = minecraft.gui.hud.getTabList();
+    var overlayAccessor = (PlayerTabOverlayAccessor) overlay;
+    var scoreboard = minecraft.level.getScoreboard();
+    var objective = scoreboard.getDisplayObjective(DisplaySlot.LIST);
+
+    var players =
+        minecraft.player.connection.getListedOnlinePlayers().stream()
+            .sorted(PLAYER_COMPARATOR)
+            .limit(80)
+            .map(
+                info -> {
+                  var data = new TabListPlayerData();
+                  var profile = info.getProfile();
+                  data.uuid = profile.id().toString();
+                  data.name = profile.name();
+                  data.display_name = textData(minecraft, overlay.getNameForDisplay(info));
+                  data.latency = info.getLatency();
+                  data.game_mode = info.getGameMode().getName();
+                  data.team = info.getTeam() == null ? null : info.getTeam().getName();
+                  data.order = info.getTabListOrder();
+                  data.skin_texture = info.getSkin().body().texturePath().toString();
+                  data.show_hat = info.showHat();
+
+                  if (objective != null) {
+                    var scoreInfo =
+                        scoreboard.getPlayerScoreInfo(ScoreHolder.fromGameProfile(profile), objective);
+                    if (scoreInfo != null) {
+                      data.score = scoreInfo.value();
+                      if (objective.getRenderType() != ObjectiveCriteria.RenderType.HEARTS) {
+                        data.score_display =
+                            textData(
+                                minecraft,
+                                scoreInfo.formatValue(
+                                    objective.numberFormatOrDefault(
+                                        StyledFormat.PLAYER_LIST_DEFAULT)));
+                      }
+                    }
+                  }
+                  return data;
+                })
+            .toArray(TabListPlayerData[]::new);
+
+    var objectiveData =
+        objective == null
+            ? null
+            : new TabListObjectiveData(
+                objective.getName(),
+                textData(minecraft, objective.getDisplayName()),
+                objective.getRenderType().getSerializedName());
+
+    return new TabListData(
+        players,
+        textData(minecraft, overlayAccessor.minescript$getHeader()),
+        textData(minecraft, overlayAccessor.minescript$getFooter()),
+        objectiveData);
+  }
+
+  private static TabListTextData textData(Minecraft minecraft, Component component) {
+    if (component == null) {
+      return null;
+    }
+    var json =
+        ComponentSerialization.CODEC
+            .encodeStart(
+                minecraft.level.registryAccess().createSerializationContext(JsonOps.INSTANCE),
+                component)
+            .getOrThrow();
+    return new TabListTextData(component.getString(), json);
+  }
+}

--- a/common/src/main/java/net/minescript/common/dataclasses/TabListData.java
+++ b/common/src/main/java/net/minescript/common/dataclasses/TabListData.java
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2022-2026 Greg Christiana <maxuser@minescript.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package net.minescript.common.dataclasses;
+
+import net.minescript.common.Jsonable;
+
+/** Snapshot of the in-game player list. */
+public class TabListData extends Jsonable {
+  private final TabListPlayerData[] players;
+  private final TabListTextData header;
+  private final TabListTextData footer;
+  private final TabListObjectiveData objective;
+
+  public TabListData(
+      TabListPlayerData[] players,
+      TabListTextData header,
+      TabListTextData footer,
+      TabListObjectiveData objective) {
+    this.players = players;
+    this.header = header;
+    this.footer = footer;
+    this.objective = objective;
+  }
+
+  public TabListPlayerData[] players() {
+    return players;
+  }
+
+  public TabListTextData header() {
+    return header;
+  }
+
+  public TabListTextData footer() {
+    return footer;
+  }
+
+  public TabListObjectiveData objective() {
+    return objective;
+  }
+}

--- a/common/src/main/java/net/minescript/common/dataclasses/TabListObjectiveData.java
+++ b/common/src/main/java/net/minescript/common/dataclasses/TabListObjectiveData.java
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2022-2026 Greg Christiana <maxuser@minescript.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package net.minescript.common.dataclasses;
+
+import net.minescript.common.Jsonable;
+
+/** Scoreboard objective displayed in the player list, if present. */
+public class TabListObjectiveData extends Jsonable {
+  public final String name;
+  public final TabListTextData display_name;
+  public final String render_type;
+
+  public TabListObjectiveData(String name, TabListTextData displayName, String renderType) {
+    this.name = name;
+    this.display_name = displayName;
+    this.render_type = renderType;
+  }
+}

--- a/common/src/main/java/net/minescript/common/dataclasses/TabListPlayerData.java
+++ b/common/src/main/java/net/minescript/common/dataclasses/TabListPlayerData.java
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2022-2026 Greg Christiana <maxuser@minescript.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package net.minescript.common.dataclasses;
+
+import net.minescript.common.Jsonable;
+
+/** Snapshot of an entry displayed in the in-game player list. */
+public class TabListPlayerData extends Jsonable {
+  public String uuid;
+  public String name;
+  public TabListTextData display_name;
+  public int latency;
+  public String game_mode;
+  public String team = null;
+  public int order;
+  public String skin_texture;
+  public boolean show_hat;
+  public Integer score = null;
+  public TabListTextData score_display = null;
+}

--- a/common/src/main/java/net/minescript/common/dataclasses/TabListTextData.java
+++ b/common/src/main/java/net/minescript/common/dataclasses/TabListTextData.java
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2022-2026 Greg Christiana <maxuser@minescript.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package net.minescript.common.dataclasses;
+
+import com.google.gson.JsonElement;
+import net.minescript.common.Jsonable;
+
+/** Plain and structured representations of text displayed in the player list. */
+public class TabListTextData extends Jsonable {
+  public final String plain;
+  public final JsonElement json;
+
+  public TabListTextData(String plain, JsonElement json) {
+    this.plain = plain;
+    this.json = json;
+  }
+
+  public String[] lines() {
+    return plain.lines().toArray(String[]::new);
+  }
+}

--- a/common/src/main/java/net/minescript/common/mixin/PlayerTabOverlayAccessor.java
+++ b/common/src/main/java/net/minescript/common/mixin/PlayerTabOverlayAccessor.java
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2022-2026 Greg Christiana <maxuser@minescript.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+package net.minescript.common.mixin;
+
+import net.minecraft.client.gui.components.PlayerTabOverlay;
+import net.minecraft.network.chat.Component;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(PlayerTabOverlay.class)
+public interface PlayerTabOverlayAccessor {
+  @Accessor("header")
+  Component minescript$getHeader();
+
+  @Accessor("footer")
+  Component minescript$getFooter();
+}

--- a/common/src/main/resources/minescript.mixins.json
+++ b/common/src/main/resources/minescript.mixins.json
@@ -13,7 +13,8 @@
     "KeyboardHandlerMixin",
     "KeyMappingMixin",
     "LevelRendererMixin",
-    "MouseHandlerMixin"
+    "MouseHandlerMixin",
+    "PlayerTabOverlayAccessor"
   ],
   "client": [],
   "injectors": {

--- a/common/src/main/resources/system/lib/minescript.py
+++ b/common/src/main/resources/system/lib/minescript.py
@@ -592,6 +592,107 @@ class EntityData:
   nbt: str = None
 
 
+@dataclass(frozen=True)
+class TabListText:
+  """Minecraft text in both plain-text and structured JSON forms."""
+  plain: str
+  json: Any
+
+  def lines(self) -> List[str]:
+    """Returns the plain text split into lines."""
+    return self.plain.splitlines()
+
+
+@dataclass(frozen=True)
+class TabListPlayer:
+  """Snapshot of a player-list entry, including server-created fake players."""
+  uuid: str
+  name: str
+  display_name: TabListText
+  latency: int
+  game_mode: str
+  team: str = None
+  order: int = 0
+  skin_texture: str = None
+  show_hat: bool = True
+  score: int = None
+  score_display: TabListText = None
+
+
+@dataclass(frozen=True)
+class TabListObjective:
+  """Scoreboard objective displayed beside player-list entries."""
+  name: str
+  display_name: TabListText
+  render_type: str
+
+
+class TabListData:
+  """Snapshot of the player-list overlay."""
+
+  def __init__(self, players, header, footer, objective):
+    self._players = [
+        TabListPlayer(
+            **dict(player, display_name=TabListText(**player["display_name"]),
+                   score_display=(None if player["score_display"] is None
+                                  else TabListText(**player["score_display"]))))
+        for player in players]
+    self._header = None if header is None else TabListText(**header)
+    self._footer = None if footer is None else TabListText(**footer)
+    self._objective = (
+        None if objective is None else
+        TabListObjective(
+            **dict(objective, display_name=TabListText(**objective["display_name"]))))
+
+  def players(self) -> List[TabListPlayer]:
+    """Returns the entries rendered in the player list, in display order."""
+    return self._players
+
+  def header(self) -> Union[TabListText, None]:
+    """Returns the text above the player entries, or `None`."""
+    return self._header
+
+  def footer(self) -> Union[TabListText, None]:
+    """Returns the text below the player entries, or `None`."""
+    return self._footer
+
+  def objective(self) -> Union[TabListObjective, None]:
+    """Returns the scoreboard objective rendered beside entries, or `None`."""
+    return self._objective
+
+
+def tablist() -> TabListData:
+  """Gets a snapshot of the in-game player-list overlay.
+
+  Unlike `players()`, this reads the client network entries used by the Tab key overlay. This
+  includes server-created "fake players" that do not exist as entities in the world.
+
+  Each `TabListText` value includes convenient plain text and the original structured Minecraft
+  JSON text, preserving colors, styling, translations, and other component metadata.
+
+  Example:
+    ```python
+    current_tablist = minescript.tablist()
+    player_names = [player.display_name.plain for player in current_tablist.players()]
+    header_lines = [] if current_tablist.header() is None else current_tablist.header().lines()
+    footer = None if current_tablist.footer() is None else current_tablist.footer().plain
+    ```
+
+  Returns:
+    `TabListData` containing the displayed entries, header, footer, and optional list scoreboard
+    objective. Entries are returned in the same order and with the same 80-entry limit as the
+    vanilla overlay.
+
+  Since: v5.0
+  """
+  return ()
+
+def _tablist_result_transform(result):
+  return TabListData(**result)
+
+tablist = ScriptFunction("tablist", tablist, _tablist_result_transform)
+
+
 def player_get_targeted_entity(max_distance: float = 20, nbt: bool = False) -> Union[EntityData, None]:
   """Gets the entity targeted in the local player's crosshairs, if any.
 

--- a/common/src/main/resources/system/pyj/minescript.py
+++ b/common/src/main/resources/system/pyj/minescript.py
@@ -518,6 +518,33 @@ def players(
 get_players = players  # Alias for scripts with `players` variables.
 
 
+def tablist() -> TabListData:
+  """Gets a snapshot of the in-game player-list overlay.
+
+  Unlike `players()`, this reads the client network entries used by the Tab key overlay. This
+  includes server-created "fake players" that do not exist as entities in the world.
+
+  Each `TabListText` value includes convenient plain text and the original structured Minecraft
+  JSON text, preserving colors, styling, translations, and other component metadata.
+
+  Example:
+    ```python
+    current_tablist = minescript.tablist()
+    player_names = [player.display_name.plain for player in current_tablist.players()]
+    header_lines = [] if current_tablist.header() is None else current_tablist.header().lines()
+    footer = None if current_tablist.footer() is None else current_tablist.footer().plain
+    ```
+
+  Returns:
+    `TabListData` containing the displayed entries, header, footer, and optional list scoreboard
+    objective. Entries are returned in the same order and with the same 80-entry limit as the
+    vanilla overlay.
+
+  Since: v5.0
+  """
+  return __mcall__("tablist", [])
+
+
 def entities(
     nbt: bool = False, uuid: str = None, name: str = None, type: str = None,
     position: Vector3f = None, offset: Vector3f = None, min_distance: float = None,

--- a/docs/README.md
+++ b/docs/README.md
@@ -939,6 +939,11 @@ is specified.
 - [`set_interval`](#set_interval)
 - [`set_timeout`](#set_timeout)
 - [`show_chat_screen`](#show_chat_screen)
+- [`tablist`](#tablist)
+- [`TabListData`](#tablistdata)
+- [`TabListObjective`](#tablistobjective)
+- [`TabListPlayer`](#tablistplayer)
+- [`TabListText`](#tablisttext)
 - [`TakeItemEvent`](#takeitemevent)
 - [`TargetedBlock`](#targetedblock)
 - [`TickEvent`](#tickevent)
@@ -1436,6 +1441,94 @@ Since: v3.0
   passengers: List[str] = None  # UUIDs of passengers as strings
   nbt: str = None
 ```
+
+#### TabListText
+Minecraft text in both plain-text and structured JSON forms.
+```
+  plain: str
+  json: Any
+```
+
+#### TabListText.lines
+*Usage:* <code>TabListText.lines() -> List[str]</code>
+
+Returns the plain text split into lines.
+
+#### TabListPlayer
+Snapshot of a player-list entry, including server-created fake players.
+```
+  uuid: str
+  name: str
+  display_name: TabListText
+  latency: int
+  game_mode: str
+  team: str = None
+  order: int = 0
+  skin_texture: str = None
+  show_hat: bool = True
+  score: int = None
+  score_display: TabListText = None
+```
+
+#### TabListObjective
+Scoreboard objective displayed beside player-list entries.
+```
+  name: str
+  display_name: TabListText
+  render_type: str
+```
+
+#### TabListData
+Snapshot of the player-list overlay.
+
+#### TabListData.players
+*Usage:* <code>TabListData.players() -> List[TabListPlayer]</code>
+
+Returns the entries rendered in the player list, in display order.
+
+#### TabListData.header
+*Usage:* <code>TabListData.header() -> Union[TabListText, None]</code>
+
+Returns the text above the player entries, or `None`.
+
+#### TabListData.footer
+*Usage:* <code>TabListData.footer() -> Union[TabListText, None]</code>
+
+Returns the text below the player entries, or `None`.
+
+#### TabListData.objective
+*Usage:* <code>TabListData.objective() -> Union[TabListObjective, None]</code>
+
+Returns the scoreboard objective rendered beside entries, or `None`.
+
+#### tablist
+*Usage:* <code>tablist() -> [TabListData](#tablistdata)</code>
+
+Gets a snapshot of the in-game player-list overlay.
+
+Unlike [`players()`](#players), this reads the client network entries used by the Tab key overlay. This
+includes server-created "fake players" that do not exist as entities in the world.
+
+Each [`TabListText`](#tablisttext) value includes convenient plain text and the original structured Minecraft
+JSON text, preserving colors, styling, translations, and other component metadata.
+
+*Example:*
+
+```python
+current_tablist = minescript.tablist()
+player_names = [player.display_name.plain for player in current_tablist.players()]
+header_lines = [] if current_tablist.header() is None else current_tablist.header().lines()
+footer = None if current_tablist.footer() is None else current_tablist.footer().plain
+```
+
+*Returns:*
+
+- [`TabListData`](#tablistdata) containing the displayed entries, header, footer, and optional list scoreboard
+objective. Entries are returned in the same order and with the same 80-entry limit as the
+vanilla overlay.
+
+Since: v5.0
+
 
 #### player_get_targeted_entity
 *Usage:* <code>player_get_targeted_entity(max_distance: float = 20, nbt: bool = False) -> Union[EntityData, None]</code>

--- a/test/minescript_test.py
+++ b/test/minescript_test.py
@@ -577,6 +577,17 @@ def player_test():
       players)]
   expect_equal(players_with_my_name, [(name, [x, y, z], yaw, pitch)])
 
+  current_tablist = minescript.tablist()
+  tablist_players = current_tablist.players()
+  expect_contains([p.name for p in tablist_players], name)
+  for entry in tablist_players:
+    expect_true(entry.display_name.plain is not None)
+    expect_true(entry.display_name.json is not None)
+  if current_tablist.header() is not None:
+    expect_equal(current_tablist.header().lines(), current_tablist.header().plain.splitlines())
+  if current_tablist.footer() is not None:
+    expect_equal(current_tablist.footer().lines(), current_tablist.footer().plain.splitlines())
+
   entities_with_my_name = [
       (e.name, e.position, e.yaw, e.pitch)
       for e in filter(lambda e: e.name == name, entities)]


### PR DESCRIPTION
## Summary

- add `minescript.tablist()` backed by the network entries used by Minecraft's player-list overlay, so server-created fake players are included
- expose each entry's profile and display names, UUID, latency, game mode, team, ordering, skin data, hat state, and optional list score
- expose the tab-list header, footer, and optional scoreboard objective
- preserve displayed text as both convenient plain text and structured Minecraft JSON
- support Python and Pyjinn, with generated API documentation and integration coverage

## Usage

```python
current_tablist = minescript.tablist()

players = current_tablist.players()
header_lines = (
    [] if current_tablist.header() is None
    else current_tablist.header().lines()
)
footer = (
    None if current_tablist.footer() is None
    else current_tablist.footer().plain
)
```

## Live example

Tested on Donut SMP with Minecraft 26.2 and Fabric:

```text
Tablist entries: 80
Header: '\nDonut SMP\n17.4K Players\n'
Footer: '\n$ 1.7B • 37 ms\n'
First entries: w00summer, N1ckifyy, 1sand, AhuvadeDih, BabyBeastpont, BurlyCloud_, Clxudyscute, Dkockysnoot_, Eljook, Enderscore24
```

This demonstrates that the API returns the server-created tab entries as well as the multiline header and footer status text.

## Validation

- Fabric 26.2 build
- NeoForge 26.2 build
- Python and Pyjinn syntax compilation
- tab-list result transformation test with fake-player, multiline-header, and footer data
- in-game Fabric test against a real server tab list
- `git diff --check`

The Forge build could not resolve the repository's configured `net.minecraftforge:forge:26.2-60.0.0:userdev` dependency; the shared implementation compiled successfully through both Fabric and NeoForge.

Fixes #77.
